### PR TITLE
add new param space id for bot.js

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1202,6 +1202,7 @@ Bot.prototype.dm = function (person, format, message) {
  * @function
  * @param {Object} cardJson - The card JSON to render.  This can come from the Webex Buttons and Cards Designer.
  * @param {String} fallbackText - Message to be displayed on client's that can't render cards.
+ * @param {String} [spaceId] - The alternative space id
  * @returns {Promise.<Message>}
  * 
  * @see {@link https://developer.webex.com/docs/api/guides/cards#working-with-cards|Buttons and Cards Guide} for further information.
@@ -1255,7 +1256,7 @@ Bot.prototype.dm = function (person, format, message) {
  *  });
  *
  */
-Bot.prototype.sendCard = function (cardJson, fallbackText) {
+Bot.prototype.sendCard = function (cardJson, fallbackText, spaceId) {
   if (!this.active) {
     let msg = 'bot.sendCard() failed, bot is not in active state';
     if ((this.framework) && ("membershipRules" in this.framework)) {
@@ -1267,7 +1268,7 @@ Bot.prototype.sendCard = function (cardJson, fallbackText) {
   let messageObj = buildCardMsgObj(cardJson, 
     this.framework.messageFormat, fallbackText);
   // send constructed message object to room
-  messageObj.roomId = this.room.id;
+  messageObj.roomId = spaceId ? spaceId : this.room.id;
   return this.framework.webex.messages.create(messageObj);
 };
 


### PR DESCRIPTION
hi team,

I don't know if it is just me or others who also have the same experience.

I want to send 1:1 message to my bot and want my bot to post the card to a target space, so I need the sendCard function to have a param to receive the space id.