### PR TITLE
Fix mongo warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.i
 ```bash
 mkdir myproj
 cd myproj
-git clone https://github.com/webex/webex-node-bot-framework
+git clone https://github.com/WebexCommunity/webex-node-bot-framework
 npm install ./webex-node-bot-framework
 ```
 
@@ -659,7 +659,7 @@ Display help for registered Framework Commands.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [header] | <code>String</code> | <code>Usage:</code> | String to use in header before displaying help message. |
-| [footer] | <code>String</code> | <code>Powered by Webex Node Bot Framework - https://github.com/webex/webex-node-bot-framework</code> | String to use in footer before displaying help message. |
+| [footer] | <code>String</code> | <code>Powered by Webex Node Bot Framework - https://github.com/WebexCommunity/webex-node-bot-framework</code> | String to use in footer before displaying help message. |
 
 **Example**  
 ```js

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 ```bash
 mkdir myproj
 cd myproj
-git clone https://github.com/webex/webex-node-bot-framework
+git clone https://github.com/WebexCommunity/webex-node-bot-framework
 npm install ./webex-node-bot-framework
 ```
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -88,7 +88,7 @@ The following tests are availabe:
 			- Select **Connect your Application**  
 				- In the **Driver** dropdown select `Node.js`  
 				- In the **Version** dropdown select `4.1 or later`  
-				- Copy the connection string presented.   It should looks something like this: `mongodb+srv://frameworkTester:<password>@cluster0.0823kk.mongodb.net/?retryWrites=true&w=majority`  
+				- Copy the connection string presented.   It should looks something like this: `mongodb+srv://frameworkTester:<password>@cluster0.0823kk.mongodb.net/?retryWrites=true&writeConcern=majority`  
 	- ### Setting up the mongo environment variables  
 		- Set MONGO_URI to the connection string.  If this was copied from the Mongo Cloud GUI using the steps above, replace `<password>` with the password you saved when you created the user for the database  
 		- Set MONGO_BOT_STORE to the name of a collection to use as the storage adapter (ie: the place where data sent with `bot.store()` will be stored).   I typically set this to `frameworkTests-botStore` but it can be anything.   If this collection does not yet exist in your database it will be created automatically the first time the test runs.  

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,5 +1,10 @@
 # Version History
 
+## v 2.4.2
+
+* Update link to repo in auto generated "Powered by Webex Node Bot Framework"  help responses.
+* Recent update to mongo library was causing deprecation warnings.  Updated code and docs to use the preferred `writeConcern` syntax instead of deprecated `w` in mongo connection strings and API calls.
+
 ## v 2.4.1
 
 * Override json5 to 2.2.3 to resolve security vulnerability

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -1741,7 +1741,7 @@ Framework.prototype.clearHears = function (hearsId) {
  *
  * @function
  * @param {String} [header=Usage:] - String to use in header before displaying help message.
- * @param {String} [footer=Powered by Webex Node Bot Framework - https://github.com/webex/webex-node-bot-framework] - String to use in footer before displaying help message.
+ * @param {String} [footer=Powered by Webex Node Bot Framework - https://github.com/WebexCommunity/webex-node-bot-framework] - String to use in footer before displaying help message.
  * @returns {String}
  *
  * @example
@@ -1751,7 +1751,7 @@ Framework.prototype.clearHears = function (hearsId) {
  */
 Framework.prototype.showHelp = function (header, footer) {
   header = header ? header : 'Usage:';
-  footer = footer ? footer : 'Powered by Webex Node Bot Framework - https://github.com/webex/webex-node-bot-framework';
+  footer = footer ? footer : 'Powered by Webex Node Bot Framework - https://github.com/WebexCommunity/webex-node-bot-framework';
 
   var helpText = '';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {

--- a/storage/mongo.js
+++ b/storage/mongo.js
@@ -200,7 +200,7 @@ class MongoStore {
     let initBotStorageData = JSON.parse(JSON.stringify(initStorage));
     initBotStorageData._id = id;
     this.memStore[id] = initBotStorageData;
-    return this.botStoreCollection.insertOne(initBotStorageData, { upsert: true, w: 1 })
+    return this.botStoreCollection.insertOne(initBotStorageData, { upsert: true, writeConcern: 1 })
       .then((mReturn) => {
         debug(`Mongo response when creating default store config for spaceId: ${id}:`);
         debug(mReturn);
@@ -380,7 +380,7 @@ class MongoStore {
           let update = {};
           update[key] = "";
           return this.botStoreCollection.updateOne(
-            { _id: id }, { $unset: update }, { upsert: true, w: 1 })
+            { _id: id }, { $unset: update }, { upsert: true, writeConcern: 1 })
             .then((mongoResponse) => {
               debug('Mongo response from updating store config in bot.forget():');
               debug(mongoResponse);


### PR DESCRIPTION
To keep PR Reviews simple this is just @adamweeks recent change and a minor change to mongo API calls to removed deprecation warnings.

All tests are passing

## v 2.4.2

* Update link to repo in auto generated "Powered by Webex Node Bot Framework"  help responses.
* Recent update to mongo library was causing deprecation warnings.  Updated code and docs to use the preferred `writeConcern` syntax instead of deprecated `w` in mongo connection strings and API calls.