### PR TITLE
Fix proxy config

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -376,7 +376,7 @@ Framework.prototype.start = function () {
     let proxyUrl = this.options.httpsProxy || null;
     if (proxyUrl) {
       console.log('proxyurl exists', proxyUrl);
-      let httpsProxyAgent = new HttpsProxyAgent(url.parse(proxyUrl));
+      let httpsProxyAgent = new HttpsProxyAgent(proxyUrl);
       config.config.defaultMercuryOptions = {
         agent: httpsProxyAgent
       };

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -377,7 +377,7 @@ Framework.prototype.start = function () {
     if (proxyUrl) {
       console.log('proxyurl exists', proxyUrl);
       let httpsProxyAgent = new HttpsProxyAgent(url.parse(proxyUrl));
-      config.defaultMercuryOptions = {
+      config.config.defaultMercuryOptions = {
         agent: httpsProxyAgent
       };
     }


### PR DESCRIPTION
1. Fixed mercury agent config assignment from:
```
      config.defaultMercuryOptions = {
        agent: httpsProxyAgent
      };
```

to:

```
      config.config.defaultMercuryOptions = {
        agent: httpsProxyAgent
      };
```

2. Removed `url.parse()` from the code since node:url module has been bumped recently.
