### PR TITLE
Feat trigger update

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,26 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Mocha Tests As User",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "DEBUG": "framework"
+      },
+      "cwd": "${workspaceRoot}",
+      "args": [
+        "--exit",
+        "-u",
+        "bdd",
+        "--timeout",
+        "40000",
+        "--colors",
+        "${workspaceFolder}/test/integration-tests.js"
+      ],
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Mocha Tests Membership Rules",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "env": {

--- a/README.md
+++ b/README.md
@@ -322,9 +322,11 @@ was "mentioned".  Bots can request info for any message in 1-1 spaces.
 
 **Differences with matching string phrases when using Framework with a "Bot Account":**
 
-When a `framework.hears()` is defined with a string phrase (as opposed to regex)
-the phrase will match if it is a substring of the message.   When running as a 
-user account, the phrase will match only against the first word of the message.
+* When running as a bot account and a `framework.hears()` is defined with a string phrase (as opposed to regex) the framework will convert the string to regex, for example: "string"
+is converted to /(^| )string( |$)/i in order to see if the string exists as a substring
+of the message.
+* When running as a user account, a string phrase will match only against the first word of the message.
+* Regex phrases behave the same in a `framework.hears() for both Bot and User accounts
 
 **Differences with trigger.args using Framework with a "Bot Account":**
 
@@ -336,7 +338,6 @@ symbol and the word. With bot accounts, this behaves a bit differently.
 * If defining a `framework.hears()` using a string (not regex), `trigger.args` is a
   filtered array of words from the message that begins *after* the first match of
   bot mention.
-
 * If defining a framework.hears() using regex, the trigger.args array is the entire
   message.
 
@@ -1460,7 +1461,7 @@ Trigger Object
 | message | <code>object</code> | message that caused this trigger (if type is 'message') |
 | phrase | <code>string</code> \| <code>regex</code> | Matched lexicon phrase if any |
 | command | <code>string</code> | Portion of message text that matched phrase. |
-| prompt | <code>string</code> | Portion of message text that was not a bot mention and did not match phrase. |
+| prompt | <code>string</code> | Portion of message text that follows the command (excluding any bot mentions) |
 | args | <code>array</code> | Filtered array of words in message text. |
 | attachmentAction | <code>object</code> | attachmentAction that caused this trigger (if type is 'attachmentAction') |
 | person | <code>object</code> | Person object associated with user that sent the message or action |

--- a/docs/example1.md
+++ b/docs/example1.md
@@ -47,6 +47,11 @@ framework.hears('hello', (bot, trigger) => {
   bot.say('Hello %s!', trigger.person.displayName);
 }, '**hello** - say hello and I\'ll say hello back');
 
+// echo user input
+framework.hears('echo', (bot, trigger) => {
+  bot.say('markdown', `You said: ${trigger.prompt}`);
+}, '**echo** - I\'ll echo back the rest of your message');
+
 // get help
 framework.hears('help', (bot, trigger) => {
   bot.say('markdown', framework.showHelp());
@@ -57,7 +62,7 @@ framework.hears('help', (bot, trigger) => {
 framework.hears(/.*/gim, (bot, trigger) => {
     bot.say('Sorry, I don\'t know how to respond to "%s"', trigger.message.text);
     bot.say('markdown', framework.showHelp());
-}, 99999);
+}, 99999); 
 
 // define express path for incoming webhooks
 app.post('/framework', webhook(framework));

--- a/docs/example2.md
+++ b/docs/example2.md
@@ -22,6 +22,23 @@ framework.hears('hello', (bot, trigger) => {
   bot.say('Hello %s!', trigger.person.displayName);
 }, '**hello** - say hello and I\'ll say hello back'); // zero is default priorty
 
+// echo user input
+framework.hears('echo', (bot, trigger) => {
+  bot.say('markdown', `You said: ${trigger.prompt}`);
+}, '**echo** - I\'ll echo back the rest of your message');
+
+// get help
+framework.hears('help', (bot, trigger) => {
+  bot.say('markdown', framework.showHelp());
+}, '**help** - get a list of my commands', 0); // zero is default priorty
+
+// Its a good practice to handle unexpected input
+// Setting a priority > 0 means this will be called only if nothing else matches
+framework.hears(/.*/gim, (bot, trigger) => {
+    bot.say('Sorry, I don\'t know how to respond to "%s"', trigger.message.text);
+    bot.say('markdown', framework.showHelp());
+}, 99999); 
+
 // define restify path for incoming webhooks
 server.post('/framework', webhook(framework));
 

--- a/docs/example3.md
+++ b/docs/example3.md
@@ -50,6 +50,11 @@ framework.hears('hello', (bot, trigger) => {
   bot.say('Hello %s!', trigger.person.displayName);
 }, '**hello** - say hello and I\'ll say hello back'); // zero is default priorty
 
+// echo user input
+framework.hears('echo', (bot, trigger) => {
+  bot.say('markdown', `You said: ${trigger.prompt}`);
+}, '**echo** - I\'ll echo back the rest of your message');
+
 // Its a good practice to handle unexpected input
 // Setting a priority > 0 means this will be called only if nothing else matches
 framework.hears(/.*/gim, (bot, trigger) => {

--- a/docs/header.md
+++ b/docs/header.md
@@ -11,6 +11,18 @@ For developers who are familiar with flint, or who wish to port existing bots bu
 Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.   This project is community supported so contributions are welcome.   If you are interested in making the framework better please see the [Contribution Guidelines](./docs/contributing.md).
 
 ## News
+* March, 2023 - Version 2.5.0 introduces two new elments of the [Trigger object](#Trigger)
+  * `trigger.command` will now contain the component of the user message that matched the `framework.hears` phrase.
+  * `trigger.prompt` will contain all of the user message that was NOT part of the command or the bot mention.
+
+This should simplify logic that uses part of the user message, for example:
+```js
+// echo user input
+framework.hears('echo', (bot, trigger) => {
+  bot.say('markdown', `You said: ${trigger.prompt}`);
+}, '**echo** - I\'ll echo back the rest of your message');
+```
+
 * May, 2020 - Version 2 introduces a some new configuration options designed to help developers restrict access to their bot.   This can be helpful during the development phase (`guideEmails` parameter) or for production bots that should be restricted for use to users that have certain email domains (`restrictedToEmailDomains` parameter).   See [Membership-Rules README](./docs/membership-rules-readme.md)
   
 * October 31, 2020 - Earlier this year, a series of blog posts were published to help developers get started building bots with the framework:

--- a/docs/license.md
+++ b/docs/license.md
@@ -2,7 +2,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2021
+Copyright (c) 2016-2023
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -135,9 +135,11 @@ was "mentioned".  Bots can request info for any message in 1-1 spaces.
 
 **Differences with matching string phrases when using Framework with a "Bot Account":**
 
-When a `framework.hears()` is defined with a string phrase (as opposed to regex)
-the phrase will match if it is a substring of the message.   When running as a 
-user account, the phrase will match only against the first word of the message.
+* When running as a bot account and a `framework.hears()` is defined with a string phrase (as opposed to regex) the framework will convert the string to regex, for example: "string"
+is converted to /(^| )string( |$)/i in order to see if the string exists as a substring
+of the message.
+* When running as a user account, a string phrase will match only against the first word of the message.
+* Regex phrases behave the same in a `framework.hears() for both Bot and User accounts
 
 **Differences with trigger.args using Framework with a "Bot Account":**
 
@@ -149,7 +151,6 @@ symbol and the word. With bot accounts, this behaves a bit differently.
 * If defining a `framework.hears()` using a string (not regex), `trigger.args` is a
   filtered array of words from the message that begins *after* the first match of
   bot mention.
-
 * If defining a framework.hears() using regex, the trigger.args array is the entire
   message.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -57,10 +57,10 @@ framework.hears(phrase, (bot, trigger, id) => {
 },'This is text that describes what happens when user sends phrase to bot', priority);
 ```
 
-* `phrase` : This can be either a string or a regex pattern.
-If a string, the string is matched against the first word in the room message.
-message.
+* `phrase` : This can be either a regex pattern or a string.
 If a regex pattern is used, it is matched against the entire message text.
+If a string, the phrase is matched if it is a substring of the room message.
+(This behavior differs slightly when run with a user token, see [Differences between Bot Accounts and User Accounts](#Bot-Accounts-vs.-User-Accounts.)).
 * `bot` : The bot object that is used to execute commands when the `phrase` is
 triggered.
 * `bot.<command>` : The Bot method to execute.
@@ -120,12 +120,24 @@ See [MongoStore](#MongoStore), for details on how to configure this storage adap
 
 The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
 
-## Bot Accounts
+## Bot Accounts vs. User Accounts.
+
+Most Webex bots are built using a "[Bot Account](https://developer.webex.com/docs/bots)" that was created in [Webex For Developers - Create A Bot](https://developer.webex.com/my-apps/new/bot).   
+It is also possible to build framework based applications using a "User Account" by specifying a user token obtained via a [Webex Integration](https://developer.webex.com/docs/integrations)
 
 **When using "Bot Accounts" the major differences are:**
 
-* Webhooks for message:created only trigger when the Bot is mentioned by name
-* Unable to read messages in rooms using the Webex API
+* Webhooks and websocket events for message:created only trigger when the Bot is mentioned by name
+* Unable to read all messages in Webex space using the Webex API.
+* May request the details of individual messages via the API by specifying
+a messageId.  In group space the messageID must be for a message where the bot
+was "mentioned".  Bots can request info for any message in 1-1 spaces.
+
+**Differences with matching string phrases when using Framework with a "Bot Account":**
+
+When a `framework.hears()` is defined with a string phrase (as opposed to regex)
+the phrase will match if it is a substring of the message.   When running as a 
+user account, the phrase will match only against the first word of the message.
 
 **Differences with trigger.args using Framework with a "Bot Account":**
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -54,8 +54,12 @@ node-flint provides a storage system to allow developers to store and retrieve d
 
 ## Improving the tests
 
-- [ ] Add a ability to create a bot and user on the fly for the tests
+- [ ] Add an ability to create a bot and user on the fly for the tests
 - [x] Add test case for attachmentAction events
-- [ ] Refactor the tests so the framework.isBotAccount variable is used to determine if mentions are needed in the user messages
+- [x] Refactor the tests so the framework.isBotAccount variable is used to determine if mentions are needed in the user messages
 - [x] Break out the tests so they aren't in one monolithic file but don't create a new framework each time
 - [ ] Track and report the number of times each flint event was tested, to catch gaps in event validation
+- [ ] Add test for setAuthorizer and clearAuthorizer.  Clean up authorizer logic in framework.js so it's more readable.
+- [ ] Configure tests to add the bot mention in places other than the beginning of the message
+- [ ] Ensure tests with multiple hears handlers are called in the order of the specified priority
+- [ ] Add a test to validate generated help messages

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,5 +1,11 @@
 # Version History
 
+## v 2.5.0
+* Added the new `command` and `prompt` elements to the `trigger` object that is passed as a parameter to matching `framework.hears()` callbacks.
+  * `trigger.command` will be the portion of the user message that matched the phrase specified in the `framework.hears()`
+  * `trigger.prompt` will be the remainder of the user message (minus any bot mention).
+* New tests added for this new functionality uncovered a bug in the membership-rules feature. If config option `membershipRulesStateMessageResponse` is set, a disabled bot due to membership rules can respond with a the configured message.  If multiple `hears()` phrases matched user input, the framework would send the message multiple times.  As of this release that message is only sent once per message.
+
 ## v 2.4.2
 
 * Update tests and documentation for the framework's [membership rules feature](./docs/membership-rules-readme.md), while enables developers to build bots that will only work with certain users or companies.

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -3,7 +3,7 @@
 ## v 2.5.0
 * Added the new `command` and `prompt` elements to the `trigger` object that is passed as a parameter to matching `framework.hears()` callbacks.
   * `trigger.command` will be the portion of the user message that matched the phrase specified in the `framework.hears()`
-  * `trigger.prompt` will be the remainder of the user message (minus any bot mention).
+  * `trigger.prompt` will be words in the message that follow the command (minus any bot mention).
 * New tests added for this new functionality uncovered a bug in the membership-rules feature. If config option `membershipRulesStateMessageResponse` is set, a disabled bot due to membership rules can respond with a the configured message.  If multiple `hears()` phrases matched user input, the framework would send the message multiple times.  As of this release that message is only sent once per message.
 
 ## v 2.4.2

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -1183,7 +1183,7 @@ Framework.prototype.onMessageCreated = function (message) {
             }
           }
 
-          _.forEach(matched, lex => {
+          _.forEach(matched, (lex, i) => {
             // for regex
             if (lex.phrase instanceof RegExp && typeof lex.action === 'function') {
               // define trigger.args, trigger.phrase
@@ -1193,7 +1193,7 @@ Framework.prototype.onMessageCreated = function (message) {
               calcCommandAndPrompt(trigger, lex.phrase);
 
               // run action
-              if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
+              if ((!membershipRules) || (membershipRules.shouldCallHears(i, bot, trigger))) {
                 bot.framework.log(`(Hears Called) framework.hears(${lex.phrase},...)`);
                 lex.action(bot, trigger, id);
               }
@@ -1214,7 +1214,7 @@ Framework.prototype.onMessageCreated = function (message) {
               calcCommandAndPrompt(trigger, lex.phrase);
 
               // run action
-              if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
+              if ((!membershipRules) || (membershipRules.shouldCallHears(i, bot, trigger))) {
                 bot.framework.log(`(Hears Called) framework.hears("${lex.phrase}",...)`); 
                 lex.action(bot, trigger, id);
               }
@@ -1691,6 +1691,14 @@ Framework.prototype.despawn = function (roomId, actorId) {
  * framework.hears(/(^| )beer( |.|$)/i, (bot, trigger) => {
  *   bot.say('Enjoy a beer, %s! 🍻', trigger.person.displayName);
  * });
+ * 
+ * @example
+ * // echo user input using trigger.prompt
+ * framework.hears('echo', (bot, trigger) => {
+ *   if (trigger.command == 'echo') {
+ *     bot.say('markdown', `You said: ${trigger.prompt}`);
+ *   }
+ * }, '**echo** - I\'ll echo back the rest of your message');
  * 
  * @example
  * // create hears handlers that use the helpText and preference params

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -657,6 +657,8 @@ Framework.prototype.getTrigger = function (type, triggerObject) {
    * @property {string} id - Message or attachentAction ID
    * @property {object} message - message that caused this trigger (if type is 'message')
    * @property {(string|regex)} phrase - Matched lexicon phrase if any
+   * @property {string} command - Portion of message text that matched phrase.
+   * @property {string} prompt - Portion of message text that was not a bot mention and did not match phrase.
    * @property {array} args - Filtered array of words in message text.
    * @property {object} attachmentAction - attachmentAction that caused this trigger (if type is 'attachmentAction')
    * @property {object} person - Person object associated with user that sent the message or action
@@ -1158,6 +1160,14 @@ Framework.prototype.onMessageCreated = function (message) {
     return this.getTrigger('message', message)
       .then(trigger => {
 
+        let textForCommandAndPrompt = trigger.text;
+        // function to calculate the trigger.[command,prompt]
+        function calcCommandAndPrompt(t, phrase) {
+            let match = textForCommandAndPrompt.match(phrase)
+            t.command = match[0];
+            t.prompt = textForCommandAndPrompt.replace(t.command, '');
+        }
+
         // function to run the action
         function runActions(matched, bot, trigger, framework) {
           const id = framework.id;
@@ -1180,6 +1190,8 @@ Framework.prototype.onMessageCreated = function (message) {
               trigger.args = trigger.text.split(' ');
               trigger.phrase = lex.phrase;
 
+              calcCommandAndPrompt(trigger, lex.phrase);
+
               // run action
               if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
                 bot.framework.log(`(Hears Called) framework.hears(${lex.phrase},...)`);
@@ -1198,6 +1210,8 @@ Framework.prototype.onMessageCreated = function (message) {
               trigger.args = trigger.text.split(' ');
               trigger.args = trigger.args.slice(indexOfMatch, trigger.args.length);
               trigger.phrase = lex.phrase;
+
+              calcCommandAndPrompt(trigger, lex.phrase);
 
               // run action
               if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
@@ -1218,6 +1232,9 @@ Framework.prototype.onMessageCreated = function (message) {
         if (trigger.message.mentionedPeople && _.includes(trigger.message.mentionedPeople, this.person.id)) {
 
           trigger.args = trigger.text.split(' ');
+          // Remove bot name for use in calculating command and prompt
+          textForCommandAndPrompt = trigger.text.replace(RegExp(`${bot.person.displayName}\\s?`), '')
+
 
           /**
            * Bot Mentioned.

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -658,7 +658,7 @@ Framework.prototype.getTrigger = function (type, triggerObject) {
    * @property {object} message - message that caused this trigger (if type is 'message')
    * @property {(string|regex)} phrase - Matched lexicon phrase if any
    * @property {string} command - Portion of message text that matched phrase.
-   * @property {string} prompt - Portion of message text that was not a bot mention and did not match phrase.
+   * @property {string} prompt - Portion of message text that follows the command (excluding any bot mentions)
    * @property {array} args - Filtered array of words in message text.
    * @property {object} attachmentAction - attachmentAction that caused this trigger (if type is 'attachmentAction')
    * @property {object} person - Person object associated with user that sent the message or action
@@ -1162,10 +1162,12 @@ Framework.prototype.onMessageCreated = function (message) {
 
         let textForCommandAndPrompt = trigger.text;
         // function to calculate the trigger.[command,prompt]
+        // command is the portion of message that matches the phrase
+        // prompt is the words in the msg that follow the command
         function calcCommandAndPrompt(t, phrase) {
             let match = textForCommandAndPrompt.match(phrase)
             t.command = match[0];
-            t.prompt = textForCommandAndPrompt.replace(t.command, '');
+            t.prompt = textForCommandAndPrompt.slice(match.index+match[0].length)
         }
 
         // function to run the action

--- a/lib/membership-rules.js
+++ b/lib/membership-rules.js
@@ -298,11 +298,13 @@ class MembershipRules {
    * @param {Object} trigger object causing callback
    * @returns {bool} 
    */
-  shouldCallHears(lex, bot, trigger) {
+  shouldCallHears(matchedPhraseIndex, bot, trigger) {
     try {
       if (!bot.active) {   // TODO is this sufficient or should I check in the deactive list?
         // Respond that the bot is no longer active because of membership rules
-        if (this.framework.membershipRulesStateMessageResponse) {
+        // but only for the first framework.hears(phrase, ..) match
+        if ((matchedPhraseIndex == 0) &&
+            (this.framework.membershipRulesStateMessageResponse)) {
           this.framework.webex.messages.create({
             roomId: bot.room.id,
             markdown: this.framework.membershipRulesStateMessageResponse

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-late-discovery": "node_modules/.bin/mocha test/late-discovery-tests.js --timeout 50000 --exit",
     "test-membership-rules": "node_modules/.bin/mocha test/membership-rules-tests.js --timeout 50000 --exit",
     "test-guide-mode-rules": "node_modules/.bin/mocha test/guide-rules-tests.js --timeout 50000 --exit",
-    "test-all": "node_modules/.bin/mocha test/bot-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/invalid-config-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/integration-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/mongo-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/late-discovery-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/guide-rules-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/membership-rules-tests.js --timeout 50000 --exit",
+    "test-all": "node_modules/.bin/mocha test/bot-tests.js --timeout 50000 --exit  && node_modules/.bin/mocha test/guide-rules-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/membership-rules-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/invalid-config-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/integration-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/mongo-tests.js --timeout 50000 --exit && node_modules/.bin/mocha test/late-discovery-tests.js --timeout 50000 --exit",
     "build": "cd docs && ./build.sh && cd .."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {

--- a/test/common/bot-created-room-tests.js
+++ b/test/common/bot-created-room-tests.js
@@ -1,5 +1,6 @@
 // Variables an functions shared by all tests
 var common = require("../common/common");
+let tm = require("../common/test-messages")
 let framework = common.framework;
 let userWebex = common.userWebex;
 let User_Test_Space_Title = common.User_Test_Space_Title;
@@ -352,41 +353,8 @@ describe('User Created Room to create a Test Bot', () => {
     });
 
     describe('#user.webex.message.create()', () => {
-      // Define the messages we want to try sending to the bot
-      let testMessages = [
-        {msgText: 'hi', hearsInfo: {phrase: 'hi'}},
-        {
-          msgText: `Here is a file for ya`,
-          msgFiles: process.env.HOSTED_FILE,
-          hearsInfo: {phrase: /.*file.*/im}
-        },
-        {
-          msgText: `Here is a whole mess of stuff for ya`,
-          hearsInfo: {
-            phrase: /.*/igm,
-            helpString: '',
-            priority: 99
-          }
-        },
-        {
-          msgText: `Here is a Some Stuff for ya`,
-          hearsInfo: {
-            phrase: /.*Some Stuf.*/igm,
-            helpString: '',
-            priority: 2 // lower number == higher priority
-          }
-        }
-      ];
-
-      // Clean up the hears functions we registered
-      after(() => {
-        testMessages.forEach((testData) => {
-          framework.clearHears(testData.hearsInfo.functionId);
-        });
-      });
-
       // loop through message tests..
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
         eventsData = {bot: botCreatedRoomBot};
 
         it(`user says ${testData.msgText}`, () => {
@@ -401,8 +369,13 @@ describe('User Created Room to create a Test Bot', () => {
           return common.botRespondsToTrigger(testName, framework,
             botCreatedRoomBot, eventsData);
         });
-      });
 
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
+        });
+      });
     });
 
     describe('bot.sendCard', () => {

--- a/test/common/bot-created-room-tests.js
+++ b/test/common/bot-created-room-tests.js
@@ -360,8 +360,7 @@ describe('User Created Room to create a Test Bot', () => {
         it(`user says ${testData.msgText}`, () => {
           let testName = `user says ${testData.msgText}`;
           return common.userSendMessage(testName, framework, userWebex,
-            botCreatedRoomBot, eventsData, testData.hearsInfo,
-            testData.msgText, testData.msgFiles);
+            botCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot responds to ${testData.msgText}`, () => {

--- a/test/common/bot-direct-message-tests.js
+++ b/test/common/bot-direct-message-tests.js
@@ -19,13 +19,6 @@ describe('Bot interacts with user in 1-1 space', () => {
   let origFormat = framework.messageFormat;
   framework.messageFormat = 'markdown';
 
-  // if (!common.botForUser1on1Space) {
-  //   console.error('No 1-1 space to run direct message tests.  This isn\'t bad, it just is...');
-  //   console.error('If you want to run the direct message tests, manually create a 1-1 space with your test bot and test user.');
-  //   return;
-  // }
-
-
   let messageCreatedEvent, frameworkMessageEvent, botMessageEvent;
   // Before running tests check if the test bot exists in a 1-1 space with test user
   // If not generate an info message that 1-1 tests will be skipped
@@ -100,11 +93,15 @@ describe('Bot interacts with user in 1-1 space', () => {
     testName = 'hears the user without needing to be mentioned';
     // Wait for the hears event associated with the input text
     const heard = new Promise((resolve) => {
-      framework.hears(/^DM: hi.*/igm, (b, t) => {
+      framework.hears(/^DM: hi, /i, (b, t) => {
         assert((b.id === common.botForUser1on1Space.id),
           'bot returned in fint.hears("hi") is not the one expected');
         assert(validator.objIsEqual(t, eventsData.trigger),
           'trigger returned in framework.hears(/^hi.*/) was not as expected');
+        assert(t.command == 'DM: Hi, ',
+          `trigger.command returned in framework.hears(/^DM: hi, /) was not as expected`);
+        assert(t.prompt == 'this is a message with no mentions.',
+          `trigger.prompt returned in framework.hears(/^DM: hi, /) was not as expected`);
         trigger = t;
         framework.debug('Bot heard message  that user posted');
         resolve(true);

--- a/test/common/bot-membership-rules-tests.js
+++ b/test/common/bot-membership-rules-tests.js
@@ -116,8 +116,7 @@ describe('User Created Room to create a Test Bot', () => {
         it(`user says ${testData.msgText}`, () => {
           let testName = `user says ${testData.msgText}`;
           return common.userSendMessage(testName, framework, userWebex,
-            botCreatedRoomBot, eventsData, testData.hearsInfo,
-            testData.msgText, testData.msgFiles);
+            botCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot should respond to ${testData.msgText}`, () => {
@@ -163,8 +162,7 @@ describe('User Created Room to create a Test Bot', () => {
             eventsData = {bot: botCreatedRoomBot};
             framework.debug(`${testName} test starting...`);
             return common.userSendMessage(testName, framework, userWebex,
-              botCreatedRoomBot, eventsData,
-              testData.hearsInfo, testData.msgText, testData.msgFiles);
+              botCreatedRoomBot, eventsData, testData);
           });
 
           it(`bot shouldn't respond to ${testData.msgText}`, () => {
@@ -284,8 +282,7 @@ describe('User Created Room to create a Test Bot', () => {
         it(`allowed user says ${testData.msgText}`, () => {
           let testName = `allowed user says ${testData.msgText}`;
           return common.userSendMessage(testName, framework, disallowedUser,
-            botCreatedRoomBot, eventsData, testData.hearsInfo,
-            testData.msgText, testData.msgFiles);
+            botCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot shouldn't respond to ${testData.msgText} from allowed user`, () => {
@@ -326,8 +323,7 @@ describe('User Created Room to create a Test Bot', () => {
             eventsData = {bot: botCreatedRoomBot};
             framework.debug(`${testName} test starting...`);
             return common.userSendMessage(testName, framework, userWebex,
-              botCreatedRoomBot, eventsData,
-              testData.hearsInfo, testData.msgText, testData.msgFiles);
+              botCreatedRoomBot, eventsData, testData);
           });
 
           it(`bot should not respond to ${testData.msgText}`, () => {
@@ -369,8 +365,7 @@ describe('User Created Room to create a Test Bot', () => {
             eventsData = {bot: botCreatedRoomBot};
             framework.debug(`${testName} test starting...`);
             return common.userSendMessage(testName, framework, userWebex,
-              botCreatedRoomBot, eventsData,
-              testData.hearsInfo, testData.msgText, testData.msgFiles);
+              botCreatedRoomBot, eventsData, testData);
           });
 
           it(`bot should respond to ${testData.msgText}`, () => {

--- a/test/common/bot-membership-rules-tests.js
+++ b/test/common/bot-membership-rules-tests.js
@@ -1,5 +1,6 @@
 // Variables an functions shared by all tests
 var common = require("../common/common");
+let tm = require("../common/test-messages")
 let framework = common.framework;
 let userWebex = common.userWebex;
 let disallowedUser = common.getDisallowedUser();
@@ -12,16 +13,6 @@ let when = common.when;
 describe('User Created Room to create a Test Bot', () => {
   let userCreatedTestRoom, userCreatedRoomBot;
   let eventsData = {};
-  // Define the messages we want to try sending to the bot
-  let testMessages = [
-    {msgText: 'hi', hearsInfo: {phrase: 'hi'}},
-    {
-      msgText: `Here is a file for ya`,
-      msgFiles: process.env.HOSTED_FILE,
-      hearsInfo: {phrase: /.*file.*/im}
-    }
-  ];
-
   // Create a room as user to have test bot which will create other rooms
   before(() => userWebex.rooms.create({title: User_Test_Space_Title})
     .then((r) => {
@@ -119,7 +110,7 @@ describe('User Created Room to create a Test Bot', () => {
 
 
       // loop through message tests..
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
         eventsData = {bot: botCreatedRoomBot};
 
         it(`user says ${testData.msgText}`, () => {
@@ -136,13 +127,12 @@ describe('User Created Room to create a Test Bot', () => {
             botCreatedRoomBot, eventsData, shouldBeAllowed);
         });
 
-      });
-
-      it(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-        testMessages.forEach((testData) => {
-          framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-          framework.clearHears(testData.hearsInfo.functionId);
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
         });
+
       });
 
 
@@ -157,14 +147,6 @@ describe('User Created Room to create a Test Bot', () => {
             });
         });
 
-        after(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-          testName = "cleans up the hears handlers from these tests";
-          testMessages.forEach((testData) => {
-            framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-            framework.clearHears(testData.hearsInfo.functionId);
-          });
-        });
-
         after(() => {
           testName = "removes a disallowed user from the room";
           return common.botRemoveUserFromSpace(testName, framework, botCreatedRoomBot,
@@ -174,7 +156,7 @@ describe('User Created Room to create a Test Bot', () => {
         });
 
         // loop through message tests..
-        testMessages.forEach((testData) => {
+        tm.testMessages.forEach((testData) => {
 
           it(`user says "${testData.msgText}" to disallowed bot`, () => {
             let testName = `user says ${testData.msgText} to disallowed bot`;
@@ -193,6 +175,11 @@ describe('User Created Room to create a Test Bot', () => {
               botCreatedRoomBot, eventsData, shouldBeAllowed);
           });
 
+          it(`clears framework.hears for ${testData.msgText}`, () => {
+            testData.hearsInfo.forEach((info) => {
+              framework.clearHears(info.functionId);
+            });
+          });
         });
 
         it(`validates that bot.say() fails in disallowed state`, () => {
@@ -291,7 +278,7 @@ describe('User Created Room to create a Test Bot', () => {
       });
 
       // loop through message tests from disallowed user
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
         eventsData = {bot: botCreatedRoomBot};
 
         it(`allowed user says ${testData.msgText}`, () => {
@@ -308,14 +295,14 @@ describe('User Created Room to create a Test Bot', () => {
             botCreatedRoomBot, eventsData, shouldBeAllowed);
         });
 
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
+        });
+
       });
 
-      it(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-        testMessages.forEach((testData) => {
-          framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-          framework.clearHears(testData.hearsInfo.functionId);
-        });
-      });
 
       describe('Removes the first disallowed user to the space', () => {
 
@@ -331,16 +318,8 @@ describe('User Created Room to create a Test Bot', () => {
             });
         });
 
-        after(() => {
-          testName = "cleans up the hears handlers from these tests";
-          testMessages.forEach((testData) => {
-            framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-            framework.clearHears(testData.hearsInfo.functionId);
-          });
-        });
-
         // loop through message tests..
-        testMessages.forEach((testData) => {
+        tm.testMessages.forEach((testData) => {
 
           it(`user says "${testData.msgText}" to disallowed bot`, () => {
             let testName = `user says ${testData.msgText} to disallowed bot`;
@@ -359,6 +338,11 @@ describe('User Created Room to create a Test Bot', () => {
               botCreatedRoomBot, eventsData, shouldBeAllowed);
           });
 
+          it(`clears framework.hears for ${testData.msgText}`, () => {
+            testData.hearsInfo.forEach((info) => {
+              framework.clearHears(info.functionId);
+            });
+          });
         });
 
       });
@@ -377,16 +361,8 @@ describe('User Created Room to create a Test Bot', () => {
             });
         });
 
-        after(() => {
-          testName = "cleans up the hears handlers from these tests";
-          testMessages.forEach((testData) => {
-            framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-            framework.clearHears(testData.hearsInfo.functionId);
-          });
-        });
-
         // loop through message tests..
-        testMessages.forEach((testData) => {
+        tm.testMessages.forEach((testData) => {
 
           it(`user says "${testData.msgText}" to disallowed bot`, () => {
             let testName = `user says ${testData.msgText} to disallowed bot`;
@@ -404,6 +380,12 @@ describe('User Created Room to create a Test Bot', () => {
             return common.botRespondsToTrigger(testName, framework,
               botCreatedRoomBot, eventsData, shouldBeAllowed);
           });
+
+          it(`clears framework.hears for ${testData.msgText}`, () => {
+            testData.hearsInfo.forEach((info) => {
+              framework.clearHears(info.functionId);
+            });
+          });  
 
         });
 

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -571,30 +571,6 @@ module.exports = {
       eventPromises = this.getInactiveBotEventArray(testName, isMention, framework, msgObj, eventsData, hearsInfo);
     }
 
-    // // Check if this test includes any specific framework.hears() syntax
-    // if (eventsData.hearsSyntax) {
-    //   let hearsPromises = []
-    //   for (syntax in eventsData.hearsSyntax) {
-    //     let calledHearsPromise = new Promise((resolve) => {
-    //       framework.hears(syntax.phrase, (b, t) => {
-    //         framework.debug(`hears(${syntax.phrase}) fired for "${t.message.html}"`);
-    //         assert((b.id === bot.id),
-    //           `bot returned in framework.hears(${syntax.phrase}) is not the one expected`);
-    //         assert(validator.objIsEqual(t.command, syntax.command),
-    //           `trigger.command returned in framework.hears(${syntax.phrase}) was not as expected`);
-    //         assert(validator.objIsEqual(t.prompt, syntax.prompt),
-    //           `trigger.prompt returned in framework.hears(${syntax.phrase}) was not as expected`);
-    //         assert(validator.objIsEqual(t.message, eventsData.message),
-    //           `trigger.message returned in framework.hears(${syntax.phrase}) was not as expected`);
-    //         resolve(true);
-    //       }), hearsInfo.helpString, hearsInfo.priority;
-    //     });
-    //     if (bot.active) {
-    //       // Only wait for it to be called if our bot is active (not disabled for guide mode)
-    //       eventPromises.push(calledHearsPromise);
-    //     }
-    //   }
-    // } else {
     // Register the specified framework.hears handlers for the message 
     hearsInfo.forEach((info) => {
       let calledHearsPromise = new Promise((resolve) => {

--- a/test/common/guided-mode-rules-tests.js
+++ b/test/common/guided-mode-rules-tests.js
@@ -103,8 +103,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
           eventsData.expectHearsSwallowed = true;
           framework.debug(`${testName} test starting...`);
           return common.userSendMessage(testName, framework, disallowedUser,
-            userCreatedRoomBot, eventsData,
-            testData.hearsInfo, testData.msgText, testData.msgFiles);
+            userCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot should not respond to ${testData.msgText}`, () => {
@@ -137,8 +136,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
         it(`user says ${testData.msgText}`, () => {
           let testName = `user says ${testData.msgText}`;
           return common.userSendMessage(testName, framework, userWebex,
-            userCreatedRoomBot, eventsData, testData.hearsInfo,
-            testData.msgText, testData.msgFiles);
+            userCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot should respond to ${testData.msgText}`, () => {
@@ -176,8 +174,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
           eventsData = {bot: userCreatedRoomBot};
           framework.debug(`${testName} test starting...`);
           return common.userSendMessage(testName, framework, disallowedUser,
-            userCreatedRoomBot, eventsData,
-            testData.hearsInfo, testData.msgText, testData.msgFiles);
+            userCreatedRoomBot, eventsData, testData);
         });
 
         it(`bot should not respond to ${testData.msgText}`, () => {

--- a/test/common/guided-mode-rules-tests.js
+++ b/test/common/guided-mode-rules-tests.js
@@ -1,6 +1,7 @@
 // Variables an functions shared by all tests
 const when = require("when");
 var common = require("../common/common");
+let tm = require("../common/test-messages")
 let framework = common.framework;
 let userWebex = common.userWebex;
 let disallowedUser = common.getDisallowedUser();
@@ -29,15 +30,6 @@ paramCombos.forEach(function(paramCombo, testIndex) {
   describe(`Non Guide Creates Room with Bot for test ${testIndex + 1}`, () => {
     let userCreatedTestRoom, userCreatedRoomBot;
     let eventsData = {};
-    // Define the messages we want to try sending to the bot
-    let testMessages = [
-      {msgText: 'hi', hearsInfo: {phrase: 'hi'}},
-      {
-        msgText: `Here is a file for ya`,
-        msgFiles: process.env.HOSTED_FILE,
-        hearsInfo: {phrase: /.*file.*/im}
-      }
-    ];
 
     // Set the framework guide mode bot response params for this test
     before(() => {
@@ -101,7 +93,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
 
     describe('Non guide user iteracts with bot', () => {
       // loop through message tests..
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
       
         it(`user says "${testData.msgText}" to disallowed bot`, () => {
           let testName = `user says ${testData.msgText} to disallowed bot`;
@@ -123,12 +115,10 @@ paramCombos.forEach(function(paramCombo, testIndex) {
             userCreatedRoomBot, eventsData, shouldBeAllowed);
         });
     
-      });
-      
-      it(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-        testMessages.forEach((testData) => {
-          framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-          framework.clearHears(testData.hearsInfo.functionId);
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
         });
       });
     });
@@ -141,7 +131,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
       });
 
       // loop through message tests..
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
         eventsData = {expectHearsSwallowed: false};
 
         it(`user says ${testData.msgText}`, () => {
@@ -158,13 +148,11 @@ paramCombos.forEach(function(paramCombo, testIndex) {
             userCreatedRoomBot, eventsData, shouldBeAllowed);
         });
 
-      });
-
-      it(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-        testMessages.forEach((testData) => {
-          framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-          framework.clearHears(testData.hearsInfo.functionId);
-        });
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
+        }); 
       });
     });
 
@@ -180,7 +168,7 @@ paramCombos.forEach(function(paramCombo, testIndex) {
 
 
       // loop through message tests again after guide is removed
-      testMessages.forEach((testData) => {
+      tm.testMessages.forEach((testData) => {
         eventsData = {bot: userCreatedRoomBot};
     
         it(`user says "${testData.msgText}" to disallowed bot`, () => {
@@ -199,14 +187,12 @@ paramCombos.forEach(function(paramCombo, testIndex) {
           return common.botRespondsToTrigger(testName, framework,
             userCreatedRoomBot, eventsData, shouldBeAllowed);
         });
-    
-      });
-    
-      it(`Removes the framework.hears() handlers setup in previous ` + `${testMessages.length * 2} tests`, () => {
-        testMessages.forEach((testData) => {
-          framework.debug(`Cleaning up framework.hears(${testData.hearsInfo.phrase})...`);
-          framework.clearHears(testData.hearsInfo.functionId);
-        });
+
+        it(`clears framework.hears for ${testData.msgText}`, () => {
+          testData.hearsInfo.forEach((info) => {
+            framework.clearHears(info.functionId);
+          });
+        });          
       });
     });
 

--- a/test/common/test-messages.js
+++ b/test/common/test-messages.js
@@ -4,11 +4,13 @@
  * 
  * @property {string} msgText - message user will send in the test
  * @property {string} msgFiles - url to a file to include in message
+ * @property {int} mentionIndex - 0 index word position where bot mention should be added
+ *                                if not set, bot mention is inserted before msgText
  * @property {array} hearsInfo - array of objects that describes a 
  *                                hears() handler to register for the test
  * 
- * @namespace {object} hearsInfo
- * Object to describe how to register a hears() handler.  Only phrase is required
+ * @namespace {object} hearsInfo[]
+ * Array of object to describe how to register hears() handler.  Only phrase is required
  * @property {string | regex} phrase - phrase for hears handler
  * @property {string} helpstring - help message to register with handler
  * @property {integer} priority - priority of hears handler
@@ -98,7 +100,30 @@ let testMessages = [
           //priority: 100 // lower number == higher priority
         }
       ]
-    }
+    },
+    {
+      msgText: `hello. please echo this is the echo message`,
+      // This will result in "hello. please @bot echo this is the echo message"
+      mentionIndex: 2,
+      hearsInfo: [
+        {
+          phrase: /(^| )echo/i,
+          command: ' echo',
+          prompt: 'hello. please this is the echo message',
+          helpString: '',
+          // Will fix multiple different priority tests in subsequent PR
+          // priority: 2 // lower number == higher priority
+        },
+        {
+          phrase: /.*/,
+          command: 'hello. please echo this is the echo message',
+          prompt: '',
+          helpString: 'This is the catch all',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 100 // lower number == higher priority
+        }
+      ]
+    }    
   ];
 
 module.exports =  {testMessages}

--- a/test/common/test-messages.js
+++ b/test/common/test-messages.js
@@ -22,6 +22,9 @@
  * - bot-membership-rules-tests.js  
  * - guide-mode-rules-tests.jus                           
  * - user-created-room-tests.js
+ * 
+ * During iterative development is may be helpful to comment out all but one or
+ * two problematic phrases while running tests
  */
 
 // TODO - Add some hearsInfo phrases that should not match and update the test
@@ -81,19 +84,19 @@ let testMessages = [
       ]
     },
     {
-      msgText: `just do it`,
+      msgText: `just do it man`,
       hearsInfo: [
         {
           phrase: /(^| )do it($| )/i,
-          command: ' do it',
-          prompt: 'just',
+          command: ' do it ',
+          prompt: 'man',
           helpString: '',
           // Will fix multiple different priority tests in subsequent PR
           // priority: 2 // lower number == higher priority
         },
         {
           phrase: /.*/,
-          command: 'just do it',
+          command: 'just do it man',
           prompt: '',
           helpString: 'This is the catch all',
           // Will fix multiple different priority tests in subsequent PR
@@ -107,9 +110,32 @@ let testMessages = [
       mentionIndex: 2,
       hearsInfo: [
         {
-          phrase: /(^| )echo/i,
-          command: ' echo',
-          prompt: 'hello. please this is the echo message',
+          phrase: /(^| )echo( |$)/i,
+          command: ' echo ',
+          prompt: 'this is the echo message',
+          helpString: '',
+          // Will fix multiple different priority tests in subsequent PR
+          // priority: 2 // lower number == higher priority
+        },
+        {
+          phrase: /.*/,
+          command: 'hello. please echo this is the echo message',
+          prompt: '',
+          helpString: 'This is the catch all',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 100 // lower number == higher priority
+        }
+      ]
+    },    
+    {
+      msgText: `hello. please echo this is the echo message`,
+      // This will result in "hello. please echo this is the echo message @bot"
+      mentionIndex: 7,
+      hearsInfo: [
+        {
+          phrase: /(^| )echo( |$)/i,
+          command: ' echo ',
+          prompt: 'this is the echo message',
           helpString: '',
           // Will fix multiple different priority tests in subsequent PR
           // priority: 2 // lower number == higher priority

--- a/test/common/test-messages.js
+++ b/test/common/test-messages.js
@@ -1,0 +1,104 @@
+/**
+ * Define a common set of test messages along with data on how to set up 
+ * related framework.hears() handlers to validate framework behavior.
+ * 
+ * @property {string} msgText - message user will send in the test
+ * @property {string} msgFiles - url to a file to include in message
+ * @property {array} hearsInfo - array of objects that describes a 
+ *                                hears() handler to register for the test
+ * 
+ * @namespace {object} hearsInfo
+ * Object to describe how to register a hears() handler.  Only phrase is required
+ * @property {string | regex} phrase - phrase for hears handler
+ * @property {string} helpstring - help message to register with handler
+ * @property {integer} priority - priority of hears handler
+ * @property {string} command - expected value in trigger.command
+ * @property {string} prompt - expected value in trigger.prompt
+ * 
+ * All messages defined here will be used in the following tests:
+ * - bot-created-room-tests.js   
+ * - bot-membership-rules-tests.js  
+ * - guide-mode-rules-tests.jus                           
+ * - user-created-room-tests.js
+ */
+
+// TODO - Add some hearsInfo phrases that should not match and update the test
+// framework to check that the appropriate ones have (or have not) been called
+ 
+let testMessages = [
+    {msgText: 'hi', hearsInfo: [{phrase: 'hi'}]},
+    {
+      msgText: `Here is a file for ya`,
+      msgFiles: process.env.HOSTED_FILE,
+      hearsInfo: [{phrase: /.*file.*/im}]
+    },
+    {
+      msgText: `Here is a whole mess of stuff for ya`,
+      hearsInfo: [{
+        phrase: /.*/im,
+        helpString: '',
+        priority: 99
+      }]
+    },
+    {
+      msgText: `Here is a Some Stuff for ya`,
+      hearsInfo: [
+        {
+          phrase: /.*Some Stuf.*/im,
+          helpString: '',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 2 // lower number == higher priority
+        },
+        {
+          phrase: /.*/im,
+          helpString: 'This is the catch all',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 100 // lower number == higher priority
+        }
+      ]
+    },
+    {
+      msgText: `echo this is the echo message`,
+      hearsInfo: [
+        {
+          phrase: /echo\s/,
+          command: 'echo ',
+          prompt: 'this is the echo message',
+          helpString: '',
+          // Will fix multiple different priority tests in subsequent PR
+          // priority: 2 // lower number == higher priority
+        },
+        {
+          phrase: /.*/,
+          command: 'echo this is the echo message',
+          prompt: '',
+          helpString: 'This is the catch all',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 100 // lower number == higher priority
+        }
+      ]
+    },
+    {
+      msgText: `just do it`,
+      hearsInfo: [
+        {
+          phrase: /(^| )do it($| )/i,
+          command: ' do it',
+          prompt: 'just',
+          helpString: '',
+          // Will fix multiple different priority tests in subsequent PR
+          // priority: 2 // lower number == higher priority
+        },
+        {
+          phrase: /.*/,
+          command: 'just do it',
+          prompt: '',
+          helpString: 'This is the catch all',
+          // Will fix multiple different priority tests in subsequent PR
+          //priority: 100 // lower number == higher priority
+        }
+      ]
+    }
+  ];
+
+module.exports =  {testMessages}

--- a/test/common/user-created-room-tests.js
+++ b/test/common/user-created-room-tests.js
@@ -58,9 +58,8 @@ describe('User Created Rooms Tests', () => {
 
       it(`user says ${testData.msgText}`, () => {
         let testName =`user says ${testData.msgText}`;
-        return common.userSendMessage(testName, framework, userWebex,
-          bot, eventsData, testData.hearsInfo,
-          testData.msgText, testData.msgFiles);
+        return common.userSendMessage(testName, framework,
+          userWebex, bot, eventsData, testData);
       });
 
       it(`bot responds to ${testData.msgText}`, () => {

--- a/test/common/user-created-room-tests.js
+++ b/test/common/user-created-room-tests.js
@@ -1,5 +1,6 @@
 // Variables an functions shared by all tests
 var common = require("../common/common");
+let tm = require("../common/test-messages")
 let framework = common.framework;
 let userWebex = common.userWebex;
 let User_Test_Space_Title = common.User_Test_Space_Title;
@@ -30,14 +31,6 @@ describe('User Created Rooms Tests', () => {
       return validator.isBot(b);
     }));
 
-  // // remove the hears handlers we set up for these tests
-  // after(() => {
-  //   framework.clearHears(hearsHi);
-  //   framework.clearHears(hearsFile);
-  //   framework.clearHears(hearsAnything);
-  //   framework.clearHears(hearsSomeStuff);
-  // });
-
   // Bot leaves rooms
   after(() => {
     if ((!bot) || (!userCreatedTestRoom)) {
@@ -59,44 +52,12 @@ describe('User Created Rooms Tests', () => {
   });
 
   describe('#user.webex.message.create()', () => {
-    // Define the messages we want to try sending to the bot
-    let testMessages = [
-      {msgText: 'hi', hearsInfo: {phrase: 'hi'}},
-      {
-        msgText: `Here is a file for ya`,
-        msgFiles: process.env.HOSTED_FILE,
-        hearsInfo: {phrase: /.*file.*/im}
-      },
-      {
-        msgText: `Here is a whole mess of stuff for ya`,
-        hearsInfo: {
-          phrase: /.*/im,
-          helpString: '',
-          priority: 99
-        }
-      },
-      {
-        msgText: `Here is a Some Stuff for ya`,
-        hearsInfo: {
-          phrase: /.*Some Stuf.*/im,
-          helpString: '',
-          priority: 2 // lower number == higher priority
-        }
-      }
-    ];
-
-    after(() => {
-      testMessages.forEach((testData) => {
-        framework.clearHears(testData.hearsInfo.functionId);
-      });
-    });
-
     // loop through message tests..
-    testMessages.forEach((testData) => {
+    tm.testMessages.forEach((testData) => {
       eventsData = {bot: bot};
 
       it(`user says ${testData.msgText}`, () => {
-        let testName = `user says ${testData.msgText}`;
+        let testName =`user says ${testData.msgText}`;
         return common.userSendMessage(testName, framework, userWebex,
           bot, eventsData, testData.hearsInfo,
           testData.msgText, testData.msgFiles);
@@ -106,6 +67,12 @@ describe('User Created Rooms Tests', () => {
         let testName = `bot responds to ${testData.msgText}`;
         return common.botRespondsToTrigger(testName, framework,
           bot, eventsData);
+      });
+
+      it(`clears framework.hears for ${testData.msgText}`, () => {
+        testData.hearsInfo.forEach((info) => {
+          framework.clearHears(info.functionId);
+        });
       });
     });
 


### PR DESCRIPTION
@adamweeks  at long last!   As part of the review, I'd be interested to hear if you think the documentation for this is sufficient.

Tests changed significantly in order to support some of the unit tests we defined.  Previously the tests assumed that each test message will have one and only one hears() callback associated with it.  The new tests support one and two hears.  I  would like to expand this further to support variable numbers of callbacks and to test that priorities are properly handled but opted to keep that out of this PR to keep things relatively simple.   Net/Net, don't get too hung up on understanding the testing, although it would be awesome to hear that anyone else is able to run the tests.

## v 2.5.0
* Added the new `command` and `prompt` elements to the `trigger` object that is passed as a parameter to matching `framework.hears()` callbacks.
  * `trigger.command` will be the portion of the user message that matched the phrase specified in the `framework.hears()`
  * `trigger.prompt` will be words in the message that follow the command (minus any bot mention).
* New tests added for this new functionality uncovered a bug in the membership-rules feature. If config option `membershipRulesStateMessageResponse` is set, a disabled bot due to membership rules can respond with a the configured message.  If multiple `hears()` phrases matched user input, the framework would send the message multiple times.  As of this release that message is only sent once per message.

